### PR TITLE
core: Indexed PNG encoding support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,6 +720,7 @@ dependencies = [
  "include_dir",
  "log",
  "num_cpus",
+ "png",
  "rayon",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ tsify = "0.5.5"
 wasm-bindgen = "0.2.100"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 env_logger = "0.11"
-anyhow = "1.0"
 anydir = "0.1.2"
 tabled = "0.19.0"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,6 +28,7 @@ serde_json.workspace = true
 include_dir = "0.7"
 env_home = "0.1.0"
 ico = "0.4.0"
+png = "0.17.16"
 
 
 [features]

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -76,10 +76,14 @@ impl fmt::Display for Config {
 
 impl Config {
     const MAX_QUANT_LEVEL: u8 = 5;
+    const MAX_PALETTE_SIZE: usize = 255; // Actual max is 256, but 1 is reserved for transparency
 
     pub fn validate(&self) -> Result<()> {
-        if self.palette.colors.is_empty() {
-            return Err(Error::EmptyPalette);
+        if self.palette.colors.is_empty() || self.palette.colors.len() > 256 {
+            return Err(Error::InvalidPaletteSize {
+                size: self.palette.colors.len(),
+                max: Self::MAX_PALETTE_SIZE,
+            });
         }
 
         if self.quant_level > Self::MAX_QUANT_LEVEL {

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -28,8 +28,10 @@ pub enum Error {
     #[error("Not a valid GIF file")]
     InvalidGifFile,
 
-    #[error("Empty palette: at least one color is required")]
-    EmptyPalette,
+    #[error(
+        "Invalid palette size: must have at least one color and at most {max} colors, got {size}"
+    )]
+    InvalidPaletteSize { size: usize, max: usize },
 
     #[error("Invalid quant_level: must be between 0 (to disable) and {max}, got {value}")]
     InvalidQuantLevel { value: u8, max: u8 },

--- a/core/src/media/gif.rs
+++ b/core/src/media/gif.rs
@@ -145,6 +145,7 @@ impl Gif {
                 buffer: frame.buffer().clone(),
                 width: frame.buffer().width(),
                 height: frame.buffer().height(),
+                palette: None,
             };
             image.resize(target_width, target_height, scale, filter)?;
             *frame = Frame::from_parts(image.buffer, frame.left(), frame.top(), frame.delay());


### PR DESCRIPTION
Much smaller file sizes if you choose a palettized mapping. E.g. a 128MB 8k image is now more like 26MB